### PR TITLE
Methods to simulate camera sensor and lens aberrations

### DIFF
--- a/Generation/imagegen-resources.py
+++ b/Generation/imagegen-resources.py
@@ -1,0 +1,26 @@
+# Alex Black
+# Set of methods to simulate expected lens issues.
+# Sensor artifacts, using camera properties
+def noise( img, iso = 100, exposure = .005, signalToNoise = 70 ): # signalToNoise (gaussian) is defined at ISO100 - higher numbers are better. Typically this'll be equal to a camera's pixel pitch time 18, but research on a per-camera basis.
+	pass
+
+# Near-field distortions. These methods will only simulate distortions at point, and will not apply the distortion to the entire image.
+# Other common abberations are ignored simply due to neglectable effects with modern equiptment
+def defocus( img, blur = 0 ):
+	pass
+def tangentialAstigmatism( img, radius = 0, theta = 0, strength = 0 ):	# Basically the blur direction is tangential to the radius at a given angle 
+	pass
+def sagittalAstigmatism( img, radius = 0, theta = 0, strength = 0 ):	# Blur direction is perpendicular to the radius at a given angle. DOES NOT RETURN A ROTATED tangentialAstigmatism!
+	pass
+def fieldCurvature( img, radius = 0, strength = 0 ):	# Basically defocus but with arguments similar to other complicated methods
+	pass
+def axialChromaticAbberation( img, radius = 0, theta = 0, strength = 0 ):	# Blurs channels selectively
+	pass
+def transverseChromaticAbberation( img, radius = 0, theta = 0, strength = 0 ):	# Scales channels selectively. This is the classic 'rainbow glitch look.'
+	pass
+
+def main(): # main() method to aid debugging
+	pass
+
+if __name__ == "__main__":
+	main()

--- a/Generation/imagegen-resources.py
+++ b/Generation/imagegen-resources.py
@@ -1,26 +1,72 @@
+import cv2
+import math
+import numpy as np
+
 # Alex Black
 # Set of methods to simulate expected lens issues.
 # Sensor artifacts, using camera properties
 def noise( img, iso = 100, exposure = .005, signalToNoise = 70 ): # signalToNoise (gaussian) is defined at ISO100 - higher numbers are better. Typically this'll be equal to a camera's pixel pitch time 18, but research on a per-camera basis.
-	pass
+	var = iso / signalToNoise * exposure ** .5
+	# Starting here, credit to https://stackoverflow.com/a/30609854
+	rows, cols, ch = img.shape 
+	mean = 2 * var
+	sigma = var ** 2
+	g = np.random.normal( mean, sigma, ( rows, cols, ch ) )
+	g = g.reshape( rows, cols, ch )
+	return img + g
 
 # Near-field distortions. These methods will only simulate distortions at point, and will not apply the distortion to the entire image.
 # Other common abberations are ignored simply due to neglectable effects with modern equiptment
-def defocus( img, blur = 0 ):
-	pass
-def tangentialAstigmatism( img, radius = 0, theta = 0, strength = 0 ):	# Basically the blur direction is tangential to the radius at a given angle 
-	pass
-def sagittalAstigmatism( img, radius = 0, theta = 0, strength = 0 ):	# Blur direction is perpendicular to the radius at a given angle. DOES NOT RETURN A ROTATED tangentialAstigmatism!
-	pass
-def fieldCurvature( img, radius = 0, strength = 0 ):	# Basically defocus but with arguments similar to other complicated methods
-	pass
-def axialChromaticAbberation( img, radius = 0, theta = 0, strength = 0 ):	# Blurs channels selectively
-	pass
-def transverseChromaticAbberation( img, radius = 0, theta = 0, strength = 0 ):	# Scales channels selectively. This is the classic 'rainbow glitch look.'
-	pass
+def defocus( img, mask, blur = 0 ):	# Standard ol' blur. To simulate the effects of a lens the blur is exponential
+	img = cv2.bitwise_and( img, mask )
+	v = int( 2 ** blur )
+	if v % 2 == 1:
+		v += 1
+	return cv2.GaussianBlur( img, ( v, v ), 0 )
+def axialChromaticAbberation( img, mask, strength = 0 ):	# Blurs channels selectively, strength increases by sqrt of input. Also technically a full distortion - see below.
+	b, g, r = cv2.split ( cv2.bitwise_and( img, mask ) )
+	adjstrength = math.ceil( strength ** .5 / 2. ) * 2 + 1
+	g = cv2.GaussianBlur( g, ( adjstrength, adjstrength ), 0 )
+	if strength > 0:	# Red channel stays focused
+		b = cv2.GaussianBlur( b, ( 2 * adjstrength + 1, 2 * adjstrength + 1 ), 0 )
+	else:	# Blue channel stays focused
+		r = cv2.GaussianBlur( r, ( 2 * adjstrength + 1, 2 * adjstrength + 1 ), 0 )
+	return cv2.merge( ( b, g, r ) )
+def transverseChromaticAbberation( img, mask, theta = 0, strength = 0 ):	# Scales channels selectively - strength is linear, theta in radians. This is the classic 'rainbow glitch look' with red as the base.
+	v = ( strength * math.cos( theta ), -1 * strength * math.sin( theta ) )	# Reverse y to account for inverse y in images
+	img = cv2.bitwise_and( img, mask )
+	rows, cols, _ = img.shape
+	b, g, r = cv2.split( img )
+	Mg = np.float32( [ [1, 0, v[ 0 ] ], [ 0, 1, v[ 1 ] ] ] )
+	Mb = np.float32( [ [1, 0, 2 * v[ 0 ] ], [ 0, 1, 2 * v[ 1 ] ] ] )
+	g = cv2.warpAffine( g, Mg, ( cols, rows ) )
+	b = cv2.warpAffine( b, Mb, ( cols, rows ) )
+	return cv2.merge( ( b, g, r ) )
+	
+# Full distortions - these tend to be significantly more difficult but the most common are implimented here
+def imageTransverseChromaticAbberation( img, strength = 0 ):	# This is a full-image transverse chromatic abberation. Slow because of multiple scalings.
+	b, g, r = cv2.split( img )
+	rows, cols, _ = img.shape
+	g = cv2.resize( g, ( cols + 2 * abs( strength ) , rows + 2 * abs( strength ) ), interpolation = cv2.INTER_AREA )
+	g = g[ abs( strength ):( abs( strength ) + rows ), abs( strength ):(abs( strength ) + cols ) ]
+	if strength > 0:	# Red treated as base.
+		b = cv2.resize( b, ( cols + 4 * strength , rows + 4 * strength ), interpolation = cv2.INTER_AREA )
+		b = b[ ( 2 * strength ):( 2 * strength + rows ), ( 2 * strength ):( 2 * strength + cols ) ]
+	else:	# strength < 0, blue treated as base.
+		strength *= -1	# Invert strength value
+		r = cv2.resize( r, ( cols + 4 * strength , rows + 4 * strength ), interpolation = cv2.INTER_AREA )
+		r = r[ ( 2 * strength ):( 2 * strength + rows ), ( 2 * strength ):( 2 * strength + cols ) ]
+	return cv2.merge( ( b, g, r ) )
 
+import os
 def main(): # main() method to aid debugging
-	pass
+	img = cv2.imread( 'flower.JPG' )
+	#img = transverseChromaticAbberation( img, img, 2, 6 )	# No mask, just use same image as mask
+	#img = axialChromaticAbberation( img, img, 1000 )
+	#img = noise( img, iso = 1600 , exposure = .01 )
+	img = imageTransverseChromaticAbberation( img, strength = 25 )
+
+	cv2.imwrite( 'a.png', img )
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
 # This merge brings the ability to simulate camera defects as seen:

## Examples
Example usage of code:
`	img = cv2.imread( 'cross.png' )`
`	img = transverseChromaticAbberation( img, img, 2.5, 1 )`
`	img = axialChromaticAbberation( img, img, 5 )`
`	img = noise( img, iso = 1600 ) `
`	img = cv2.blur( img, ( 2, 2 ) )`
`	cv2.imwrite( 'a.png', img )`

**Example Output 1 of target dirtying:**
![image (2)](https://user-images.githubusercontent.com/26143328/91503721-3e3c4900-e899-11ea-8f24-805251192ad8.png)

**Example Output 2 of an otherwise nice flower picture:**
![a](https://user-images.githubusercontent.com/26143328/91504082-1d282800-e89a-11ea-9eeb-ddd26672f9f1.png)
**Original for context:**
![a](https://user-images.githubusercontent.com/26143328/91504145-421c9b00-e89a-11ea-8466-1b8c96bbb241.png)



## Methods
### Noise
This method adds additive noise to a layer with simulated camera ISO and signal-to-noise as options. Though ISO is a well understood value for sensitivity, signal-to-noise is a metric of how much noise a camera sensor will possess at ISO 100. A good rule of thumb to get a sensor's signal-to noise is to multiply a sensor's pixel pitch by 18, though values may fall somewhat under this value. "70" is an accurate representation of a Sony α5000.

**Example:**
![a](https://user-images.githubusercontent.com/26143328/91501786-6aa19680-e894-11ea-9ba7-4fe4e0435649.png)


### Axial Chromatic Aberration
Different wavelengths of light will bend different amounts, though only one will be in focus. The other colors will be effectively blurred in place - the channel blurriness will vary on the strength/severity of the axial chromatic aberration.

**(Extreme) Example, red in focus:**
![a (1)](https://user-images.githubusercontent.com/26143328/91502325-c6b8ea80-e895-11ea-8abe-9bb81aefa071.png)
**(Extreme) Example, blue in focus:**
![a](https://user-images.githubusercontent.com/26143328/91502502-362eda00-e896-11ea-816a-1bcd2a874557.png)

### Transverse Chromatic Aberration
This is also known as the classic glitch effect. In the context of a photo this would be a localized effect - an actual lens would have rings of chromatic aberration - see the Image Transverse Chromatic Aberration.

**Example:**
![a](https://user-images.githubusercontent.com/26143328/91503188-e5b87c00-e897-11ea-9702-0fef54fccab6.png)

### Image Transverse Chromatic Aberration
This is the rotational version of the Transverse Chromatic Aberration function - this would be for large images, not a crop.

**Example:**
![a](https://user-images.githubusercontent.com/26143328/91503463-84dd7380-e898-11ea-88ad-232684222895.png)

